### PR TITLE
Clears up confusing language on removing rows

### DIFF
--- a/src/javascript-grid-data-update/index.php
+++ b/src/javascript-grid-data-update/index.php
@@ -221,8 +221,7 @@ interface RowDataTransaction {
     </p>
 
     <p>
-        If you are providing rowNode ID's (via the <code>getRowNodeId()</code> callback) then the
-        grid will match the rows based on ID. If you are not using ID's, then the grid will match
+        If you are providing rowNode ID's (via the <code>getRowNodeId()</code> callback) then pass an array of objects with keys corresponding to the rowNodeId you specified with <code>getRowNodeId</code> and values matching the rows you want to remove. If you are not using ID's, then the grid will match
         the rows based on object reference.
     </p>
 


### PR DESCRIPTION
Just spent SOOOO long trying to figure this out.  If I have
```
getRowNodeId: data => data.primaryKey
```
and I want to remove the row that has the primary key `abc`, I was trying to pass the transaction object 
```
{ remove: ['abc'] }
```
because I interpreted the docs as saying to do so (and also because that's the simpler approach).  Instead I really needed to pass 
```
{ remove: [{primaryKey: 'abc'}] }
```
My frustration was exacerbated by the fact that the ag-grid documentation examples for the `remove` portion of the transaction all don't use `getRowNodeId` which would have immediately helped resolve my problem much earlier.  I suggest making an example that does so.

Feel free to change my wording here as you like, just wanted to raise the point that it could be much clearer.  Perhaps adding the type of RowNode to this portion of the docs would make it clearer as well?  It would have helped me a lot in this situation since the current documentation just shows `any[]` which is more or less useless.