### PR TITLE
Add startRow and endRow properties to docs

### DIFF
--- a/src/javascript-grid-enterprise-model/index.php
+++ b/src/javascript-grid-enterprise-model/index.php
@@ -108,6 +108,12 @@ interface IEnterpriseDatasource {
 
 <pre>interface IEnterpriseGetRowsRequest {
 
+    <span class="codeComment">// The first row index to get.</span>
+    startRow: number;
+
+    <span class="codeComment">// The first row index to NOT get.</span>
+    endRow: number;
+
     <span class="codeComment">// details for the request</span>
     rowGroupCols: ColumnVO[];
 


### PR DESCRIPTION
Add startRow and endRow properties to the IEnterpriseGetRowsRequest interface documentation.

Closes #167 