### PR TITLE
typo: (85% sure) needs function to be called, not passed

### DIFF
--- a/src/react-more-details/index.php
+++ b/src/react-more-details/index.php
@@ -515,7 +515,7 @@ class TopMoversGrid extends Component {
     render() {
         return (
             &lt;AgGridReact
-                rowData={this.cleanData}
+                rowData={this.cleanData()}
                 ...rest of the component</snippet>
 
     <p>As above, this call will result in ag-Grid believing that the rowData has changed each time the component renders as the filtering


### PR DESCRIPTION
unless I'm missing something (or the typescript type is wrong) this should invoke the `cleanData` function.  it isn't bound anyway if it were passed like this, which is another reason that makes me think this could be a simple mistake