### PR TITLE
Correct mispelling of 'editorss' to 'editors'

### DIFF
--- a/src/javascript-grid-cell-editor/react.php
+++ b/src/javascript-grid-cell-editor/react.php
@@ -3,7 +3,7 @@
 </h2>
 
 <p>
-    It is possible to provide React cell editorss for ag-Grid to use if you are are using the
+    It is possible to provide React cell editors for ag-Grid to use if you are are using the
     React version of ag-Grid. See <a href="../javascript-grid-components/#registering-framework-components">
     registering framework components</a> for how to register framework components.
 </p>


### PR DESCRIPTION
Resolves #197.